### PR TITLE
Do not name AMD export

### DIFF
--- a/lib/builders/scripts.js
+++ b/lib/builders/scripts.js
@@ -66,7 +66,7 @@ Scripts.umd = function (canonical, alias, js) {
     + 'if (typeof exports == "object") {\n'
     + '  module.exports = require("' + canonical + '");\n'
     + '} else if (typeof define == "function" && define.amd) {\n'
-    +'  define("' + alias + '", [], function(){ return require("' + canonical + '"); });\n'
+    +'  define([], function(){ return require("' + canonical + '"); });\n'
     + '} else {\n'
     + '  (this || window)["' + alias + '"] = require("' + canonical + '");\n'
     + '}\n'


### PR DESCRIPTION
3-argument define call is for AMD builds only and should not be included in a UMD wrapper.

Refs chaijs/chai#362.